### PR TITLE
styleのインデックスがずれるケースを修正

### DIFF
--- a/xlsx/styles.go
+++ b/xlsx/styles.go
@@ -212,8 +212,10 @@ func NewStyles(f *zip.File) *Styles {
 			case "numFmts":
 				inNumFmts = false
 			case "xf":
-				cellStyles = append(cellStyles, c)
-				c = cellXf{}
+				if inCellXfs {
+					cellStyles = append(cellStyles, c)
+					c = cellXf{}
+				}
 			case "numFmt":
 				numFmts[numFmtId] = numfmt
 				numfmt = format{}


### PR DESCRIPTION
`cellStyles`に余分に`cellXf`が入ってインデックスがずれるケースがあるので修正しました

### 問題が起こるケース

以下のように、`cellXFs`の外に`xf`タグがある場合にゼロ値の`cellXf`が入ってしまうケースがありました

```xml
  <cellStyleXfs count="1">
    <xf borderId="0" fillId="0" fontId="0" numFmtId="0" applyAlignment="1" applyFont="1"/>
  </cellStyleXfs>
  <cellXfs count="1">
    <xf borderId="0" fillId="0" fontId="0" numFmtId="0" xfId="0" applyAlignment="1" applyFont="1">
      <alignment readingOrder="0" shrinkToFit="0" vertical="bottom" wrapText="0"/>
    </xf>
  </cellXfs>
```

これによりセルがズレて正しいフォーマットでセルの値の変換が起こらないケースが存在します

### 直し方

`cellStyles`に入れるときに`inCellXfs`が`true`かどうかを見てから入れるようにしました